### PR TITLE
Fix: Plural of "status" (stati > statuses)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ With this action you can specify the project columns in which issues should be c
 | `github_token`   | The personal access token                                                                                                                                   |     ✓    |
 | `owner`          | The user or organization that owns the repository and project                                                                                               |     ✓    |
 | `project_number` | The number of the project you target                                                                                                                        |     ✓    |   
-| `closed_stati`   | The project board column names in which issues should be closed <br> For example: `Won't do,Done` <br> _(Make sure there are no spaces between arguments)_  |     ✕    |   
-| `open_stati`     | The project board column names in which issues should be open <br> For example: `Todo,In Progress` <br> _(Make sure there are no spaces between arguments)_ |     ✕    |  
+| `closed_statuses`   | The project board column names in which issues should be closed <br> For example: `Won't do,Done` <br> _(Make sure there are no spaces between arguments)_  |     ✕    |   
+| `open_statuses`     | The project board column names in which issues should be open <br> For example: `Todo,In Progress` <br> _(Make sure there are no spaces between arguments)_ |     ✕    |  
 | `verbosity`      | The log output verbosity <br> Possible values: `info`, `debug`, `trace` <br> Default: `info`                                                                |     ✕    |
 
 ## Creating a PAT
@@ -83,8 +83,8 @@ jobs:
           github_token: ${{ secrets.PROJECT_ISSUE_SYNC_TOKEN }}
           owner: OWNER_NAME
           project_number: 1
-          closed_stati: Done
-          open_stati: Todo,In Progress
+          closed_statuses: Done
+          open_statuses: Todo,In Progress
 
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -13,10 +13,10 @@ inputs:
   project_number:
     description: 'The number of the project you target.'
     required: true
-  closed_stati:
+  closed_statuses:
     description: 'The project board column names in which issues should be closed.'
     required: false
-  open_stati:
+  open_statuses:
     description: 'The project board column names in which issues should be open.'
     required: false
   verbosity:

--- a/src/args.rs
+++ b/src/args.rs
@@ -23,14 +23,14 @@ pub struct Args {
     /// The project board column names in which issues should be closed.
     /// For example: "Won't do","Done"
     /// (Make sure there are no spaces between arguments.)
-    #[arg(short, long, env = "INPUT_CLOSED_STATI", value_delimiter(','))]
-    pub closed_stati: Vec<String>,
+    #[arg(short, long, env = "INPUT_CLOSED_STATUSES", value_delimiter(','))]
+    pub closed_statuses: Vec<String>,
 
     /// The project board column names in which issues should be open.
     /// For example: "Todo","In Progress"
     /// (Make sure there are no spaces between arguments.)
-    #[arg(short('r'), long, env = "INPUT_OPEN_STATI", value_delimiter(','))]
-    pub open_stati: Vec<String>,
+    #[arg(short('r'), long, env = "INPUT_OPEN_STATUSES", value_delimiter(','))]
+    pub open_statuses: Vec<String>,
 
     /// Log output verbosity (info, debug, trace).
     #[arg(short, long, env = "INPUT_VERBOSITY", default_value = "info")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,12 +28,12 @@ async fn main() -> Result<()> {
     SimpleLogger::init(level, Config::default()).unwrap();
 
     info!(
-        "closed_stati: {:?}, open_stati: {:?}",
-        args.closed_stati, args.open_stati
+        "closed_statuses: {:?}, open_statuses: {:?}",
+        args.closed_statuses, args.open_statuses
     );
 
-    // Inform the user if neither closed_stati nor open_stati is specified.
-    if args.closed_stati.is_empty() && args.open_stati.is_empty() {
+    // Inform the user if neither closed_statuses nor open_statuses is specified.
+    if args.closed_statuses.is_empty() && args.open_statuses.is_empty() {
         error!("No project board column names were specified.");
         std::process::exit(1);
     }
@@ -82,10 +82,10 @@ async fn main() -> Result<()> {
         std::process::exit(1);
     }
 
-    // We need the option ids of the closed and open stati to check
+    // We need the option ids of the closed and open statuses to check
     // if an item is in one of the target columns.
-    let closed_option_ids = get_option_ids(status_field, &args.closed_stati).await;
-    let open_option_ids = get_option_ids(status_field, &args.open_stati).await;
+    let closed_option_ids = get_option_ids(status_field, &args.closed_statuses).await;
+    let open_option_ids = get_option_ids(status_field, &args.open_statuses).await;
 
     // Ensure the issue state for every item.
     for item in project.items {
@@ -161,10 +161,10 @@ async fn ensure_issue_state(
     Ok(())
 }
 
-/// Get the respective option ids for the given list of stati.
-async fn get_option_ids(status_field: Option<&Field>, stati: &Vec<String>) -> Vec<String> {
+/// Get the respective option ids for the given list of statuses.
+async fn get_option_ids(status_field: Option<&Field>, statuses: &Vec<String>) -> Vec<String> {
     let mut option_ids: Vec<String> = Vec::new();
-    for status_name in stati.iter() {
+    for status_name in statuses.iter() {
         let option = status_field
             .unwrap()
             .options


### PR DESCRIPTION
Hi there! I came across a minor typo in this repository and would like to propose a quick fix. Currently, the plural form of _"status"_ is written as _"stati"_, which is incorrect. According to the [reference I found](https://en.wiktionary.org/wiki/statuses#English), the correct form is _"statuses"_.

I hope this fix is helpful and improves the clarity of the repository. 

**Note**: I wanted to add that it's technically possible to use _"status"_ as the plural form of _"status"_, but I opted to recommend _"statuses"_ for the sake of clarity.

Thank you for considering my contribution!