### PR TITLE
fix: README.md instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,12 @@ This workflow runs every 2 hours or if manually started.
 name: Project Issue State Sync
 
 on: 
-  workflow_dispatch:
+  schedule:
     # At minute 0 every 2 hours
     - cron: 0 0-23/2 * * *
+  
+  workflow_dispatch:
+    # Manual trigger
 
 jobs:
   issue-state-sync:
@@ -78,7 +81,7 @@ jobs:
 
     steps:
       - name: Sync issue states
-        uses: dasmerlon/project-issue-state-sync@v1
+        uses: dasmerlon/project-issue-state-sync@v1.0.0
         with:
           github_token: ${{ secrets.PROJECT_ISSUE_SYNC_TOKEN }}
           owner: OWNER_NAME


### PR DESCRIPTION
# Summary

This PR makes two changes to the `README.md` instructions:

1. Updates the version to match the current version on the Marketplace (`v1.0.0`); with the previous version stated (`v1`), the instruction was not functional.
2. Adds a manual trigger, and adjusts the defined trigger to run on a schedule every two hours.

# References
[GitHub Marketplace entry with the correct version](https://github.com/marketplace/actions/project-issue-state-sync)
[GitHub Actions documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows) for the trigger fixes

# Motivation

I tested this action on my repository using the instructions and ran into a few issues. However, after making these fixes, the action ran smoothly and without any problems. Hope this helps!